### PR TITLE
fdb数据库更新

### DIFF
--- a/Scripts/env.php
+++ b/Scripts/env.php
@@ -22,7 +22,7 @@
 
 //Runtime Environment Initializer
 
-require_once "../sfloader.php";
+require_once(__DIR__ . '/../sfloader.php');
 
 use iTXTech\SimpleFramework\Console\Logger;
 use iTXTech\SimpleFramework\Initializer;


### PR DESCRIPTION
### **1. 新增以下制程颗粒：**
 - Toshiba/Kioxia/Sandisk：BICS3/4/5/6/8，45FF等特殊颗粒
 - Hynix：HYV6/7
 - Samsung：3DV4/5/6/6P/7
 - YMTC：JGS/TAS/EMS/WDS/WYS
 - Micron/Spectek：B37/B47
 - 群联部分料号
 - 金士顿部分料号

（以上仅供参考，具体不清楚了，新增制程远比以上列出来的多）

群联料号没有研究透算法，只能通过查id相同料号的方式获取群联料号，或者搭配外部解码网站[fe.barryblueice.cn](http://fe.barryblueice.cn/PartNumber?param=)进行解码。
金士顿料号也是一样的。

### **2. 新增/增加支持以下主控：**

**慧荣Silicon Motion：**
 - SM2258XT/H
 - SM2259XT/H
 - SM2259XT2G
 - SM2261XT
 - SM2262EN
 - SM2263XT
 - SM2264
 - SM2508
 - SM2267
 - SM2267XT
 - SM2268XT/XT2
 - SM2269XT
 - SM2320XT/SM2320G
 - SM8266

**联芸Maxio：**
 - MAS0901
 - MAS0902
 - MAS1102
 - MAP1002
 - MAP1202
 - MAP1602

**三地一芯FirstChip：**
 - FC3379/ZC3281

**群联Phison：**
 - PS2251-07
 - PS2251-08
 - PS2251-68

（以上仅供参考，具体不清楚了，新增主控远比以上列出来的多）

### **3.其他更新：**
 - 删除了部分错误的ID和料号，但依旧建议对fdb进行大修。
 - 修复了部分id/pn没有制程的问题。
 - 对部分id/pn进行了主控支持同步。
 - 清除了部分导致无法解码的特殊unicode字符。